### PR TITLE
Correct leaflet shim

### DIFF
--- a/leafletwidget/static/leaflet.js
+++ b/leafletwidget/static/leaflet.js
@@ -5,7 +5,14 @@ require.config({
         leaflet: "%s",
         leaflet_draw: "%s"
     },
-    shim: {leaflet_draw: "leaflet"}
+    shim: {
+	leaflet: {
+	    exports: 'L'
+	},
+	leaflet_draw: {
+	    deps: ['leaflet']
+	}
+    }
 });
 
 require(["widgets/js/widget", "leaflet", "leaflet_draw"], function(WidgetManager, L) {


### PR DESCRIPTION
This fixes the issue where the leaflet draw controls don't appear due to a missing reference to the L variable (Leaflet is non-AMD).